### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-rust-embed-responder"
-version = "2.2.3"
+version = "2.3.0"
 edition = "2021"
 description = "An actix-web responder for rust-embed that implements cache revalidation and compressed responses."
 license = "MIT"
@@ -20,19 +20,19 @@ futures-core = "0.3"
 lazy_static = "1.4" # static caching stuff
 regex = "1.9" # parsing header values
 flate2 = "1.0" # gzip compressed responses when doing on-the-fly compression
-brotli = "6.0" # br compressed responses when doing on-the-fly compression
+brotli = "8.0" # br compressed responses when doing on-the-fly compression
 zstd = { version = "0.13", optional = true } # zstd compressed responses when doing on-the-fly compression
 chrono = { version = "0.4", default-features = false, features = [
   "clock",
 ] } # Parsing & serializing Last-Modified headers
 # rust-embed only
 rust-embed = { version = "8.0", optional = true }
-base64 = { version = "0.21", optional = true }    # ETag
+base64 = { version = "0.22", optional = true }    # ETag
 # rust-embed-for-web only
 rust-embed-for-web = { version = "11.3.0", optional = true }
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["async_tokio"] }
+criterion = { version = "0.7", features = ["async_tokio"] }
 tokio = { version = "1", features = ["rt"] }
 actix-http = "3.4"
 


### PR DESCRIPTION
## Summary
- Updated base64 from 0.21 to 0.22
- Updated brotli from 6.0 to 8.0
- Updated criterion from 0.5 to 0.7 (dev dependency)
- Bumped package version from 2.2.3 to 2.3.0

## Testing
- ✓ All 24 tests pass
- ✓ Project builds successfully with all features
- ✓ Both example programs (`rust_embed` and `rust_embed_for_web`) work correctly
- ✓ Compression functionality verified

## Notes
These are major version updates for the dependencies, but no code changes were required as:
- base64 API usage was already compatible with 0.22
- brotli 8.0 is a drop-in replacement
- criterion only affects benchmarks (dev dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)